### PR TITLE
Fix/rollback revive

### DIFF
--- a/docs/resources/gno-interrealm.md
+++ b/docs/resources/gno-interrealm.md
@@ -249,59 +249,13 @@ abort := revive(func() {
     })
 })
 abort == "cross-realm panic"
-```
 
-`revive(fn)` will execute 'fn' and return the exception that crossed
-a realm finalization boundary.
-
-### Transactional Semantics
-
-`revive(fn)` provides exception capture with automatic rollback for cross-realm calls:
-
-- **Exception Capture**: If `fn` panics during execution, `revive()` captures the
-  panic and returns it as an error value instead of propagating it.
-  
-- **State Rollback** (cross-realm only): When a panic crosses a realm boundary,
-  state changes are automatically rolled back. The realm's transaction is not
-  finalized, so mutations are discarded.
-  
-  **Important**: Same-realm mutations are NOT rolled back. If you need rollback
-  for same-realm code, ensure your test calls cross into a different realm.
-  
-- **Invariant Enforcement**: `fn` **must always panic**. If `fn` completes normally
-  without panicking, `revive()` will automatically panic with the message
-  "revive() function must always panic".
-  
-- **Testing Only**: This is only enabled in testing mode (when `Machine.ReviveEnabled`
-  is true). Production code cannot use `revive()`.
-
-Examples:
-
-```go
-// Cross-realm with rollback:
-ex := revive(func() {
-    Sign(cross, "test")  // Crosses into guestbook realm
-    // Any state changes in guestbook realm are rolled back
-})
-
-// Same-realm without rollback:
-var counter int
-ex := revive(func() {
-    counter++           // This mutation PERSISTS
-    panic("test")
-})
-// counter is now 1 - changes were NOT rolled back
-
-// This will panic with "revive() function must always panic":
+// revive() function must always panic:
 ex := revive(func() {
     println("completed normally")
     // ERROR: must panic!
 })
 ```
-
-TL;DR: `revive(fn)` is Gno's builtin for testing exception handling. It provides
-automatic rollback when panics cross realm boundaries, but not for same-realm mutations.
-
 
 ## `attach()`
 

--- a/docs/resources/gno-interrealm.md
+++ b/docs/resources/gno-interrealm.md
@@ -254,13 +254,54 @@ abort == "cross-realm panic"
 `revive(fn)` will execute 'fn' and return the exception that crossed
 a realm finalization boundary.
 
-This is only enabled in testing mode (for now), behavior is only partially
-implemented. In the future `revive(fn)` will be available for non-testing code,
-and the behavior will change such that `fn()` is run in transactional
-(cache-wrapped) memory context and any mutations discarded if and only if there
-was an abort.
+### Transactional Semantics
 
-TL;DR: `revive(fn)` is Gno's builtin for STM (software transactional memory).
+`revive(fn)` provides exception capture with automatic rollback for cross-realm calls:
+
+- **Exception Capture**: If `fn` panics during execution, `revive()` captures the
+  panic and returns it as an error value instead of propagating it.
+  
+- **State Rollback** (cross-realm only): When a panic crosses a realm boundary,
+  state changes are automatically rolled back. The realm's transaction is not
+  finalized, so mutations are discarded.
+  
+  **Important**: Same-realm mutations are NOT rolled back. If you need rollback
+  for same-realm code, ensure your test calls cross into a different realm.
+  
+- **Invariant Enforcement**: `fn` **must always panic**. If `fn` completes normally
+  without panicking, `revive()` will automatically panic with the message
+  "revive() function must always panic".
+  
+- **Testing Only**: This is only enabled in testing mode (when `Machine.ReviveEnabled`
+  is true). Production code cannot use `revive()`.
+
+Examples:
+
+```go
+// Cross-realm with rollback:
+ex := revive(func() {
+    Sign(cross, "test")  // Crosses into guestbook realm
+    // Any state changes in guestbook realm are rolled back
+})
+
+// Same-realm without rollback:
+var counter int
+ex := revive(func() {
+    counter++           // This mutation PERSISTS
+    panic("test")
+})
+// counter is now 1 - changes were NOT rolled back
+
+// This will panic with "revive() function must always panic":
+ex := revive(func() {
+    println("completed normally")
+    // ERROR: must panic!
+})
+```
+
+TL;DR: `revive(fn)` is Gno's builtin for testing exception handling. It provides
+automatic rollback when panics cross realm boundaries, but not for same-realm mutations.
+
 
 ## `attach()`
 

--- a/gnovm/pkg/gnolang/frame.go
+++ b/gnovm/pkg/gnolang/frame.go
@@ -33,6 +33,7 @@ type Frame struct {
 	Defers        []Defer       // deferred calls
 	IsDefer       bool          // was func defer called
 	IsRevive      bool          // calling revive()
+	SavedStore    Store         // saved store before revive()
 	LastException *Exception    // previous m.exception
 
 	// test info
@@ -41,7 +42,7 @@ type Frame struct {
 
 func (fr Frame) String() string {
 	if fr.Func != nil {
-		return fmt.Sprintf("[FRAME FUNC:%v RECV:%s (%d args) %d/%d/%d/%d/%d LASTPKG:%s LASTRLM:%v WSW:%v DSW:%v ISDEFER:%v LASTEX:%v]",
+		return fmt.Sprintf("[FRAME FUNC:%v RECV:%s (%d args) %d/%d/%d/%d/%d LASTPKG:%s LASTRLM:%v WSW:%v DSW:%v ISDEFER:%v ISREVIVE:%v LASTEX:%v]",
 			fr.Func,
 			fr.Receiver,
 			fr.NumArgs,
@@ -55,6 +56,7 @@ func (fr Frame) String() string {
 			fr.WithCross,
 			fr.DidCrossing,
 			fr.IsDefer,
+			fr.IsRevive,
 			fr.LastException,
 		)
 	} else {

--- a/gnovm/pkg/gnolang/op_call.go
+++ b/gnovm/pkg/gnolang/op_call.go
@@ -359,7 +359,7 @@ func (m *Machine) doOpReturnCallDefers() {
 				if rvfr.SavedStore != nil {
 					m.Store.CacheRestore(rvfr.SavedStore)
 				}
-				
+
 				m.PopFrameAndReturn()
 				// assign exception as return of revive().
 				resx := m.PeekValue(1)
@@ -367,13 +367,13 @@ func (m *Machine) doOpReturnCallDefers() {
 				m.Exception = nil // reset
 				return
 			}
-			
+
 			// No revive frame found - check if crossing realm boundary to abort
 			if m.isRealmBoundary(cfr) {
 				// Abort the transaction at realm boundary
 				panic(m.makeUnhandledPanicError())
 			}
-			
+
 			// Handle panic by calling OpReturnCallDefers on
 			// the next (last) call frame)
 			m.PopFrame()
@@ -387,7 +387,7 @@ func (m *Machine) doOpReturnCallDefers() {
 				m.pushPanic(typedString("revive() function must always panic"))
 				return
 			}
-			
+
 			// Otherwise continue with the return process,
 			// OpReturnFromBlock needs frame, don't pop here.
 			m.PushOp(OpReturnFromBlock)

--- a/gnovm/pkg/gnolang/store.go
+++ b/gnovm/pkg/gnolang/store.go
@@ -79,6 +79,8 @@ type Store interface {
 	GetNative(pkgPath string, name Name) func(m *Machine) // for native functions
 	SetLogStoreOps(dst io.Writer)
 	LogFinalizeRealm(rlmpath string) // to mark finalization of realm boundaries
+	CacheClone() Store                                    // creates a shallow clone of cache state for rollback
+	CacheRestore(Store)                                   // restores cache state from a clone
 	Print()
 }
 
@@ -233,6 +235,16 @@ type transactionStore struct {
 func (t transactionStore) Write() {
 	t.cacheTypes.(txlog.MapCommitter[TypeID, Type]).Commit()
 	t.cacheNodes.(txlog.MapCommitter[Location, BlockNode]).Commit()
+}
+
+// CacheClone for transactionStore delegates to the embedded defaultStore
+func (t transactionStore) CacheClone() Store {
+	return t.defaultStore.CacheClone()
+}
+
+// CacheRestore for transactionStore delegates to the embedded defaultStore
+func (t transactionStore) CacheRestore(cloned Store) {
+	t.defaultStore.CacheRestore(cloned)
 }
 
 // XXX: we should block Go2GnoType, because it uses a global cache map;
@@ -1152,6 +1164,405 @@ func (ds *defaultStore) SetLogStoreOps(buf io.Writer) {
 func (ds *defaultStore) LogFinalizeRealm(rlmpath string) {
 	if ds.opslog != nil {
 		fmt.Fprintf(ds.opslog, "finalizerealm[%q]\n", rlmpath)
+	}
+}
+
+// deepCloneObject creates a deep copy of an object for cache cloning.
+// This leverages existing Copy() methods where available to simplify implementation.
+func deepCloneObject(obj Object, alloc *Allocator) Object {
+	if obj == nil {
+		return nil
+	}
+
+	switch v := obj.(type) {
+	case *Block:
+		// Clone the block and its values - create directly to avoid source.GetNumNames() issues
+		b := &Block{
+			ObjectInfo: v.ObjectInfo.Copy(),
+			Source:     v.Source,
+			Values:     make([]TypedValue, len(v.Values)),
+			Parent:     v.Parent,
+			Blank:      v.Blank,
+			bodyStmt:   v.bodyStmt,
+		}
+		// Deep copy each value - special handling for PointerValues and HeapItemValues
+		for i := range v.Values {
+			tv := v.Values[i]
+			
+			// Special case 1: HeapItemValue needs deep cloning
+			if hi, ok := tv.V.(*HeapItemValue); ok {
+				clonedHI := deepCloneObject(hi, alloc).(*HeapItemValue)
+				b.Values[i] = TypedValue{
+					T: tv.T,
+					V: clonedHI,
+					N: tv.N,
+				}
+				continue
+			}
+			
+			// Special case 2: PointerValue needs deep cloning of Base
+			if pv, ok := tv.V.(PointerValue); ok {
+				// Clone the PointerValue and its Base object
+				newPV := PointerValue{
+					TV:    pv.TV, // Will update below
+					Base:  pv.Base,
+					Index: pv.Index,
+				}
+				
+				// Deep clone the Base if it's an Object
+				if baseObj, ok := pv.Base.(Object); ok {
+					newPV.Base = deepCloneObject(baseObj, alloc)
+					// Update TV to point into the new base
+					switch newBase := newPV.Base.(type) {
+					case *ArrayValue:
+						if pv.Index >= 0 && pv.Index < len(newBase.List) {
+							newPV.TV = &newBase.List[pv.Index]
+						}
+					case *StructValue:
+						if pv.Index >= 0 && pv.Index < len(newBase.Fields) {
+							newPV.TV = &newBase.Fields[pv.Index]
+						}
+					// Add other cases as needed
+					}
+				}
+				
+				b.Values[i] = TypedValue{
+					T: tv.T,
+					V: newPV,
+					N: tv.N,
+				}
+			} else {
+				b.Values[i] = tv.Copy(alloc)
+			}
+		}
+		return b
+
+	case *PackageValue:
+		// Clone the package value
+		pv := &PackageValue{
+			ObjectInfo: v.ObjectInfo.Copy(),
+			PkgName:    v.PkgName,
+			PkgPath:    v.PkgPath,
+			FNames:     slices.Clone(v.FNames),
+			Realm:      v.Realm,
+			Private:    v.Private,
+		}
+		
+		// Clone the block if it's a *Block (not a RefValue)
+		if block, ok := v.Block.(*Block); ok {
+			pv.Block = deepCloneObject(block, alloc)
+		} else {
+			pv.Block = v.Block
+		}
+		
+		// Clone FBlocks
+		if len(v.FBlocks) > 0 {
+			pv.FBlocks = make([]Value, len(v.FBlocks))
+			for i, fb := range v.FBlocks {
+				if block, ok := fb.(*Block); ok {
+					pv.FBlocks[i] = deepCloneObject(block, alloc)
+				} else {
+					pv.FBlocks[i] = fb
+				}
+			}
+		}
+		
+		// Clone fBlocksMap if present
+		if v.fBlocksMap != nil {
+			pv.fBlocksMap = make(map[string]*Block, len(v.fBlocksMap))
+			for k, block := range v.fBlocksMap {
+				pv.fBlocksMap[k] = deepCloneObject(block, alloc).(*Block)
+			}
+		}
+		
+		return pv
+
+	case *ArrayValue:
+		// Use existing Copy() method which handles deep copying
+		return v.Copy(alloc)
+
+	case *StructValue:
+		// Use existing Copy() method which recursively copies fields
+		return v.Copy(alloc)
+
+	case *FuncValue:
+		// Use existing Copy() method
+		return v.Copy(alloc)
+
+	case *BoundMethodValue:
+		// Clone using existing Copy() methods
+		bm := &BoundMethodValue{
+			ObjectInfo: v.ObjectInfo.Copy(),
+			Func:       v.Func.Copy(alloc),
+			Receiver:   v.Receiver.Copy(alloc),
+		}
+		return bm
+
+	case *MapValue:
+		// Deep clone MapValue by cloning the linked list structure
+		mv := &MapValue{
+			ObjectInfo: v.ObjectInfo.Copy(),
+			List:       nil,
+			vmap:       make(map[MapKey]*MapListItem, len(v.vmap)),
+		}
+		
+		if v.List != nil {
+			mv.List = &MapList{
+				Head: nil,
+				Tail: nil,
+				Size: v.List.Size,
+			}
+			
+			// Clone the linked list
+			var prevItem *MapListItem
+			for item := v.List.Head; item != nil; item = item.Next {
+				newItem := &MapListItem{
+					Key:   item.Key.Copy(alloc),
+					Value: item.Value.Copy(alloc),
+					Prev:  prevItem,
+					Next:  nil,
+				}
+				
+				if prevItem == nil {
+					mv.List.Head = newItem
+				} else {
+					prevItem.Next = newItem
+				}
+				prevItem = newItem
+				mv.List.Tail = newItem
+				
+				// Update the vmap to point to the new item
+				keyStr, _ := item.Key.ComputeMapKey(nil, false)
+				mv.vmap[keyStr] = newItem
+			}
+		}
+		
+		return mv
+
+	case *HeapItemValue:
+		// Clone heap item - need special handling for types not handled by TypedValue.Copy()
+		// TypedValue.Copy() only handles BigintValue, *ArrayValue, and *StructValue
+		// We need to manually deep clone other Object types
+		hi := &HeapItemValue{
+			ObjectInfo: v.ObjectInfo.Copy(),
+			Value:      v.Value.Copy(alloc),
+		}
+		
+		// Special case 1: MapValue needs deep cloning
+		if mapVal, ok := hi.Value.V.(*MapValue); ok {
+			clonedMap := deepCloneObject(mapVal, alloc).(*MapValue)
+			hi.Value.V = clonedMap
+		}
+		
+		// Special case 2: SliceValue needs deep cloning of its Base
+		if sv, ok := hi.Value.V.(*SliceValue); ok {
+			if baseArray, ok := sv.Base.(*ArrayValue); ok {
+				// Deep clone the base array
+				clonedBase := deepCloneObject(baseArray, alloc).(*ArrayValue)
+				hi.Value.V = &SliceValue{
+					Base:   clonedBase,
+					Offset: sv.Offset,
+					Length: sv.Length,
+					Maxcap: sv.Maxcap,
+				}
+			}
+		}
+		
+		// Special case 3: PointerValue with Object base needs deep cloning
+		if pv, ok := hi.Value.V.(PointerValue); ok {
+			if baseObj, ok := pv.Base.(Object); ok {
+				clonedBase := deepCloneObject(baseObj, alloc)
+				// Update the PointerValue to point to the cloned base
+				newPV := PointerValue{
+					TV:    pv.TV, // Will need to update this to point into cloned base
+					Base:  clonedBase,
+					Index: pv.Index,
+				}
+				// Update TV to point into the new base
+				switch nb := clonedBase.(type) {
+					case *ArrayValue:
+						if pv.Index >= 0 && pv.Index < len(nb.List) {
+							newPV.TV = &nb.List[pv.Index]
+						}
+					case *StructValue:
+						if pv.Index >= 0 && pv.Index < len(nb.Fields) {
+							newPV.TV = &nb.Fields[pv.Index]
+						}
+				}
+				hi.Value.V = newPV
+			}
+		}
+		
+		return hi
+
+	default:
+		// For other object types, return as-is
+		// This is safe for immutable objects
+		return obj
+	}
+}
+
+// CacheClone creates a deep clone of the store's cache state.
+// This is used by revive() to save cache state before execution,
+// allowing rollback on panic by restoring the cloned state.
+func (ds *defaultStore) CacheClone() Store {
+	clone := &defaultStore{
+		// Copy the references to the same underlying stores
+		baseStore: ds.baseStore,
+		iavlStore: ds.iavlStore,
+		alloc:     ds.alloc,
+
+		// Clone the caches - this is the important part
+		cacheObjects: make(map[ObjectID]Object, len(ds.cacheObjects)),
+		cacheTypes:   ds.cacheTypes, // txlog.Map handles its own state
+		cacheNodes:   ds.cacheNodes, // txlog.Map handles its own state
+
+		// Copy store configuration
+		pkgGetter:      ds.pkgGetter,
+		nativeResolver: ds.nativeResolver,
+		gasConfig:      ds.gasConfig,
+
+		// Copy transient state
+		gasMeter:  ds.gasMeter,
+		opslog:    ds.opslog,
+		current:   slices.Clone(ds.current),
+		stagingPackage: ds.stagingPackage,
+
+		// Copy realm storage diffs
+		realmStorageDiffs: make(map[string]int64, len(ds.realmStorageDiffs)),
+	}
+
+	// Deep copy the object cache map - clone each object
+	for k, v := range ds.cacheObjects {
+		clone.cacheObjects[k] = deepCloneObject(v, ds.alloc)
+	}
+
+	// Copy realm storage diffs
+	for k, v := range ds.realmStorageDiffs {
+		clone.realmStorageDiffs[k] = v
+	}
+
+	return clone
+}
+
+// CacheRestore restores cache state from a previously cloned store.
+// This is used by revive() to rollback cache mutations on panic.
+func (ds *defaultStore) CacheRestore(cloned Store) {
+	src := cloned.(*defaultStore)
+	
+	// Restore objects in-place to maintain references
+	for k, clonedObj := range src.cacheObjects {
+		if currentObj, exists := ds.cacheObjects[k]; exists {
+			// Object exists - restore its state
+			restoreObjectState(currentObj, clonedObj)
+		} else {
+			// Object was added during revive - remove it
+			delete(ds.cacheObjects, k)
+		}
+	}
+	
+	// Remove any objects that were added during the revive call
+	for k := range ds.cacheObjects {
+		if _, existsInClone := src.cacheObjects[k]; !existsInClone {
+			delete(ds.cacheObjects, k)
+		}
+	}
+	
+	// Restore other cache state
+	ds.cacheTypes = src.cacheTypes
+	ds.cacheNodes = src.cacheNodes
+	ds.stagingPackage = src.stagingPackage
+	ds.realmStorageDiffs = src.realmStorageDiffs
+}
+
+// restoreObjectState restores the state of an object from a cloned version
+func restoreObjectState(current, cloned Object) {
+	// Type validation for debugging
+	if reflect.TypeOf(current) != reflect.TypeOf(cloned) {
+		panic(fmt.Sprintf("type mismatch in restore: %T vs %T", current, cloned))
+	}
+	
+	switch cur := current.(type) {
+	case *Block:
+		if clone, ok := cloned.(*Block); ok {
+			// Restore block values - need to copy the actual values
+			if len(cur.Values) != len(clone.Values) {
+				cur.Values = make([]TypedValue, len(clone.Values))
+			}
+			for i := range clone.Values {
+				cur.Values[i] = clone.Values[i]
+				// If the value contains a PointerValue to a HeapItemValue, 
+				// the HeapItemValue will be restored separately in the cache loop
+			}
+			cur.bodyStmt = clone.bodyStmt
+		}
+	case *PackageValue:
+		if clone, ok := cloned.(*PackageValue); ok {
+			// Restore package value state
+			if curBlock, ok := cur.Block.(*Block); ok {
+				if cloneBlock, ok := clone.Block.(*Block); ok {
+					restoreObjectState(curBlock, cloneBlock)
+				}
+			} else {
+				cur.Block = clone.Block
+			}
+			
+			// Restore FBlocks
+			if len(cur.FBlocks) > 0 && len(clone.FBlocks) > 0 {
+				for i := range clone.FBlocks {
+					if curFBlock, ok := cur.FBlocks[i].(*Block); ok {
+						if cloneFBlock, ok := clone.FBlocks[i].(*Block); ok {
+							restoreObjectState(curFBlock, cloneFBlock)
+						}
+					} else {
+						cur.FBlocks[i] = clone.FBlocks[i]
+					}
+				}
+			}
+			
+			// Restore fBlocksMap
+			if cur.fBlocksMap != nil && clone.fBlocksMap != nil {
+				for k, cloneBlock := range clone.fBlocksMap {
+					if curBlock, exists := cur.fBlocksMap[k]; exists {
+						restoreObjectState(curBlock, cloneBlock)
+					} else {
+						cur.fBlocksMap[k] = cloneBlock
+					}
+				}
+			}
+		}
+	case *HeapItemValue:
+		if clone, ok := cloned.(*HeapItemValue); ok {
+			// Simply restore the entire value - this updates the PointerValue
+			// and all nested objects it points to
+			cur.Value = clone.Value
+		}
+	case *ArrayValue:
+		if clone, ok := cloned.(*ArrayValue); ok {
+			// Restore array contents
+			if len(cur.List) > 0 {
+				for i := range clone.List {
+					cur.List[i] = clone.List[i]
+				}
+			}
+			if len(cur.Data) > 0 {
+				copy(cur.Data, clone.Data)
+			}
+		}
+	case *StructValue:
+		if clone, ok := cloned.(*StructValue); ok {
+			// Restore struct fields
+			for i := range clone.Fields {
+				cur.Fields[i] = clone.Fields[i]
+			}
+		}
+	case *MapValue:
+		if clone, ok := cloned.(*MapValue); ok {
+			// Restore map state
+			cur.List = clone.List
+			cur.vmap = clone.vmap
+		}
+	// Add more cases as needed for other object types
 	}
 }
 

--- a/gnovm/pkg/gnolang/uverse.go
+++ b/gnovm/pkg/gnolang/uverse.go
@@ -1101,6 +1101,8 @@ func makeUverseNode() {
 	//       panic("test")
 	//   })
 	//   // ex contains the panic value
+	//
+	// XXX This is only enabled in testing mode (for now)
 	defNative("revive",
 		Flds( // params
 			"fn", FuncT(nil, nil),

--- a/gnovm/tests/files/revive/array_mutation.gno
+++ b/gnovm/tests/files/revive/array_mutation.gno
@@ -1,0 +1,38 @@
+package main
+
+var arr = [3]int{1, 2, 3}
+var slice = []int{10, 20, 30}
+
+func main() {
+	// Test 1: Array mutation should be rolled back
+	println("Before revive - arr:", arr[0], arr[1], arr[2])
+	
+	revive(func() {
+		arr[0] = 100
+		arr[1] = 200
+		println("Inside revive - arr:", arr[0], arr[1], arr[2])
+		panic("test panic")
+	})
+	
+	println("After revive - arr:", arr[0], arr[1], arr[2])
+	
+	// Test 2: Slice mutation should be rolled back
+	println("Before revive - slice:", slice[0], slice[1], slice[2])
+	
+	revive(func() {
+		slice[0] = 1000
+		slice[2] = 3000
+		println("Inside revive - slice:", slice[0], slice[1], slice[2])
+		panic("slice panic")
+	})
+	
+	println("After revive - slice:", slice[0], slice[1], slice[2])
+}
+
+// Output:
+// Before revive - arr: 1 2 3
+// Inside revive - arr: 100 200 3
+// After revive - arr: 1 2 3
+// Before revive - slice: 10 20 30
+// Inside revive - slice: 1000 20 3000
+// After revive - slice: 10 20 30

--- a/gnovm/tests/files/revive/array_mutation.gno
+++ b/gnovm/tests/files/revive/array_mutation.gno
@@ -6,26 +6,26 @@ var slice = []int{10, 20, 30}
 func main() {
 	// Test 1: Array mutation should be rolled back
 	println("Before revive - arr:", arr[0], arr[1], arr[2])
-	
+
 	revive(func() {
 		arr[0] = 100
 		arr[1] = 200
 		println("Inside revive - arr:", arr[0], arr[1], arr[2])
 		panic("test panic")
 	})
-	
+
 	println("After revive - arr:", arr[0], arr[1], arr[2])
-	
+
 	// Test 2: Slice mutation should be rolled back
 	println("Before revive - slice:", slice[0], slice[1], slice[2])
-	
+
 	revive(func() {
 		slice[0] = 1000
 		slice[2] = 3000
 		println("Inside revive - slice:", slice[0], slice[1], slice[2])
 		panic("slice panic")
 	})
-	
+
 	println("After revive - slice:", slice[0], slice[1], slice[2])
 }
 

--- a/gnovm/tests/files/revive/map_mutation.gno
+++ b/gnovm/tests/files/revive/map_mutation.gno
@@ -1,0 +1,32 @@
+package main
+
+var m = make(map[string]int)
+
+func main() {
+	// Test 1: Map mutation should be rolled back
+	m["initial"] = 100
+	println("Before revive:", m["initial"])
+	
+	revive(func() {
+		m["key"] = 42
+		m["initial"] = 200
+		println("Inside revive:", m["key"], m["initial"])
+		panic("test panic")
+	})
+	
+	println("After revive:", m["key"], m["initial"])
+	
+	// Test 2: Nested map operations
+	revive(func() {
+		m["nested"] = 999
+		panic("nested panic")
+	})
+	
+	println("After nested:", m["nested"])
+}
+
+// Output:
+// Before revive: 100
+// Inside revive: 42 200
+// After revive: 0 100
+// After nested: 0

--- a/gnovm/tests/files/revive/map_mutation.gno
+++ b/gnovm/tests/files/revive/map_mutation.gno
@@ -6,22 +6,22 @@ func main() {
 	// Test 1: Map mutation should be rolled back
 	m["initial"] = 100
 	println("Before revive:", m["initial"])
-	
+
 	revive(func() {
 		m["key"] = 42
 		m["initial"] = 200
 		println("Inside revive:", m["key"], m["initial"])
 		panic("test panic")
 	})
-	
+
 	println("After revive:", m["key"], m["initial"])
-	
+
 	// Test 2: Nested map operations
 	revive(func() {
 		m["nested"] = 999
 		panic("nested panic")
 	})
-	
+
 	println("After nested:", m["nested"])
 }
 

--- a/gnovm/tests/files/revive/nested_revive.gno
+++ b/gnovm/tests/files/revive/nested_revive.gno
@@ -5,27 +5,27 @@ var counter int
 func main() {
 	counter = 0
 	println("Initial:", counter)
-	
+
 	// Outer revive
 	revive(func() {
 		counter = 10
 		println("Outer revive start:", counter)
-		
+
 		// Inner revive - should roll back to 10
 		revive(func() {
 			counter = 20
 			println("Inner revive:", counter)
 			panic("inner panic")
 		})
-		
+
 		println("After inner revive:", counter)
-		
+
 		// Modify again before outer panic
 		counter = 15
 		println("Before outer panic:", counter)
 		panic("outer panic")
 	})
-	
+
 	println("After outer revive:", counter)
 }
 

--- a/gnovm/tests/files/revive/nested_revive.gno
+++ b/gnovm/tests/files/revive/nested_revive.gno
@@ -1,0 +1,38 @@
+package main
+
+var counter int
+
+func main() {
+	counter = 0
+	println("Initial:", counter)
+	
+	// Outer revive
+	revive(func() {
+		counter = 10
+		println("Outer revive start:", counter)
+		
+		// Inner revive - should roll back to 10
+		revive(func() {
+			counter = 20
+			println("Inner revive:", counter)
+			panic("inner panic")
+		})
+		
+		println("After inner revive:", counter)
+		
+		// Modify again before outer panic
+		counter = 15
+		println("Before outer panic:", counter)
+		panic("outer panic")
+	})
+	
+	println("After outer revive:", counter)
+}
+
+// Output:
+// Initial: 0
+// Outer revive start: 10
+// Inner revive: 20
+// After inner revive: 10
+// Before outer panic: 15
+// After outer revive: 0

--- a/gnovm/tests/files/revive/same_realm_mutation.gno
+++ b/gnovm/tests/files/revive/same_realm_mutation.gno
@@ -1,0 +1,45 @@
+// PKGPATH: gno.land/r/test
+package test
+
+var counter int
+
+func main() {
+	// Test 1: Same-realm mutation should be rolled back
+	counter = 0
+	
+	ex := revive(func() {
+		counter = 42  // This mutation should be rolled back
+		panic("test panic")
+	})
+	
+	if counter != 0 {
+		println("FAIL: counter should be 0 but is", counter)
+	} else {
+		println("PASS: counter correctly rolled back to 0")
+	}
+	
+	// Test 2: Multiple mutations
+	counter = 10
+	
+	ex2 := revive(func() {
+		counter = 20
+		counter = 30
+		counter = 40
+		panic("test panic 2")
+	})
+	
+	if counter != 10 {
+		println("FAIL: counter should be 10 but is", counter)
+	} else {
+		println("PASS: counter correctly rolled back to 10")
+	}
+	
+	println("Exception 1:", ex)
+	println("Exception 2:", ex2)
+}
+
+// Output:
+// PASS: counter correctly rolled back to 0
+// PASS: counter correctly rolled back to 10
+// Exception 1: test panic
+// Exception 2: test panic 2

--- a/gnovm/tests/files/revive/same_realm_mutation.gno
+++ b/gnovm/tests/files/revive/same_realm_mutation.gno
@@ -6,34 +6,34 @@ var counter int
 func main() {
 	// Test 1: Same-realm mutation should be rolled back
 	counter = 0
-	
+
 	ex := revive(func() {
-		counter = 42  // This mutation should be rolled back
+		counter = 42 // This mutation should be rolled back
 		panic("test panic")
 	})
-	
+
 	if counter != 0 {
 		println("FAIL: counter should be 0 but is", counter)
 	} else {
 		println("PASS: counter correctly rolled back to 0")
 	}
-	
+
 	// Test 2: Multiple mutations
 	counter = 10
-	
+
 	ex2 := revive(func() {
 		counter = 20
 		counter = 30
 		counter = 40
 		panic("test panic 2")
 	})
-	
+
 	if counter != 10 {
 		println("FAIL: counter should be 10 but is", counter)
 	} else {
 		println("PASS: counter correctly rolled back to 10")
 	}
-	
+
 	println("Exception 1:", ex)
 	println("Exception 2:", ex2)
 }

--- a/gnovm/tests/files/revive/struct_mutation.gno
+++ b/gnovm/tests/files/revive/struct_mutation.gno
@@ -5,7 +5,7 @@ type Point struct {
 }
 
 type Container struct {
-	P Point
+	P     Point
 	Value int
 }
 
@@ -15,19 +15,19 @@ var c = Container{P: Point{X: 1, Y: 2}, Value: 100}
 func main() {
 	// Test 1: Simple struct mutation should be rolled back
 	println("Before revive - p:", p.X, p.Y)
-	
+
 	revive(func() {
 		p.X = 99
 		p.Y = 88
 		println("Inside revive - p:", p.X, p.Y)
 		panic("test panic")
 	})
-	
+
 	println("After revive - p:", p.X, p.Y)
-	
+
 	// Test 2: Nested struct mutation should be rolled back
 	println("Before revive - c:", c.P.X, c.P.Y, c.Value)
-	
+
 	revive(func() {
 		c.P.X = 500
 		c.P.Y = 600
@@ -35,7 +35,7 @@ func main() {
 		println("Inside revive - c:", c.P.X, c.P.Y, c.Value)
 		panic("nested panic")
 	})
-	
+
 	println("After revive - c:", c.P.X, c.P.Y, c.Value)
 }
 

--- a/gnovm/tests/files/revive/struct_mutation.gno
+++ b/gnovm/tests/files/revive/struct_mutation.gno
@@ -1,0 +1,48 @@
+package main
+
+type Point struct {
+	X, Y int
+}
+
+type Container struct {
+	P Point
+	Value int
+}
+
+var p = Point{X: 10, Y: 20}
+var c = Container{P: Point{X: 1, Y: 2}, Value: 100}
+
+func main() {
+	// Test 1: Simple struct mutation should be rolled back
+	println("Before revive - p:", p.X, p.Y)
+	
+	revive(func() {
+		p.X = 99
+		p.Y = 88
+		println("Inside revive - p:", p.X, p.Y)
+		panic("test panic")
+	})
+	
+	println("After revive - p:", p.X, p.Y)
+	
+	// Test 2: Nested struct mutation should be rolled back
+	println("Before revive - c:", c.P.X, c.P.Y, c.Value)
+	
+	revive(func() {
+		c.P.X = 500
+		c.P.Y = 600
+		c.Value = 999
+		println("Inside revive - c:", c.P.X, c.P.Y, c.Value)
+		panic("nested panic")
+	})
+	
+	println("After revive - c:", c.P.X, c.P.Y, c.Value)
+}
+
+// Output:
+// Before revive - p: 10 20
+// Inside revive - p: 99 88
+// After revive - p: 10 20
+// Before revive - c: 1 2 100
+// Inside revive - c: 500 600 999
+// After revive - c: 1 2 100


### PR DESCRIPTION
Fix: https://github.com/gnolang/gno/issues/4782
Fix: https://github.com/orgs/samouraiworld/projects/10/views/1?pane=issue&itemId=144574696&issue=gnolang%7Cgno%7C2043

WIP, this is a poc

There's 3 differents situations:
- panic after crossing -> rollback already implemented in `op_call.go:L357` thanks to store cache system
- panic in same context -> copy the cache, and revert it (hence the cache deepCopy implementation)
- no panic -> We've to panic in `op_call.go`